### PR TITLE
Use *router* telemetry to measure controllers.

### DIFF
--- a/lib/prometheus_phx.ex
+++ b/lib/prometheus_phx.ex
@@ -13,7 +13,7 @@ defmodule PrometheusPhx do
 
   def setup do
     events = [
-      [:phoenix, :endpoint, :stop],
+      [:phoenix, :router_dispatch, :stop],
       [:phoenix, :error_rendered],
       [:phoenix, :channel_joined],
       [:phoenix, :channel_handled_in]
@@ -63,7 +63,7 @@ defmodule PrometheusPhx do
     )
   end
 
-  def handle_event([:phoenix, :endpoint, :stop], %{duration: duration}, metadata, _config) do
+  def handle_event([:phoenix, :router_dispatch, :stop], %{duration: duration}, metadata, _config) do
     with labels when is_list(labels) <- labels(metadata) do
       Histogram.observe(
         [


### PR DESCRIPTION
As far as I can see, phoenix does not actually instrument `:telemetry` with `:endpoint`, but rather `:router_dispatch`. 

See this search: https://github.com/phoenixframework/phoenix/search?q=%3Atelemetry.execute

This could be helpful for https://github.com/deadtrickster/prometheus-phoenix/pull/19